### PR TITLE
Change volumePermissions image to debian

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -75,7 +75,7 @@ volumePermissions:
   enabled: true
   image:
     registry: docker.io
-    repository: bitnami/minideb
+    repository: debian
     tag: latest
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
#### What this PR does / why we need it:
By changing the volumePermissions image to Debian, this chart becomes compatible with other non amd64 architectures like arm64 :). Another reason to keep this one alive next to the bitnami one :) 
